### PR TITLE
Fix default value of components in AbiData

### DIFF
--- a/tonclient/types.py
+++ b/tonclient/types.py
@@ -678,7 +678,7 @@ class AbiData:
         self.key = key
         self.name = name
         self.type = type
-        self.components = components
+        self.components = components or []
 
     @property
     def dict(self):


### PR DESCRIPTION
If components is not set in `AbiData`, then it has `None` value in dict representation. It leads to exception in `abi.encode_message` when abi type is `AbiContract` with some data values
By the way, it is already done in [AbiParams](https://github.com/move-ton/ton-client-py/blob/master/tonclient/types.py#L705)
